### PR TITLE
Pass in original host as header to backend service.

### DIFF
--- a/nginx/proxy_ssl.conf
+++ b/nginx/proxy_ssl.conf
@@ -39,6 +39,7 @@ server {
       proxy_set_header        X-Real-IP $remote_addr;
       proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header        X-Forwarded-Proto $scheme;
+      proxy_set_header        X-Forwarded-Host $http_host;
       proxy_pass              http://target_service;
       proxy_read_timeout      90;
       proxy_redirect          http:// https://;


### PR DESCRIPTION
Backend services can create full urls correctly by using this header.

If using django, relies on the use of the setting `USE_X_FORWARDED_HOST = True`
