### PR TITLE
Support lets encrypt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,9 @@ ADD start.sh /usr/src/
 ADD nginx/nginx.conf /etc/nginx/
 ADD nginx/proxy*.conf /usr/src/
 
+RUN mkdir /etc/nginx/snippets/
+RUN mkdir -p /tmp/letsencrypt/.well-known/acme-challenge/
+RUN echo "OK" > /tmp/letsencrypt/.well-known/acme-challenge/health
+ADD nginx/letsencrypt.conf /etc/nginx/snippets/letsencrypt.conf
+
 ENTRYPOINT ./start.sh

--- a/README.md
+++ b/README.md
@@ -11,12 +11,6 @@ docker build -t nginx-ssl-proxy .
 ## Using with Kubernetes
 This image is optimized for use in a Kubernetes cluster to provide SSL termination for other services in the cluster. It should be deployed as a [Kubernetes replication controller](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/replication-controller.md) with a [service and public load balancer](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/services.md) in front of it. SSL certificates, keys, and other secrets are managed via the [Kubernetes Secrets API](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/design/secrets.md).
 
-Here's how the replication controller and service would function terminating SSL for Jenkins in a Kubernetes cluster:
-
-![](img/architecture.png)
-
-See [https://github.com/GoogleCloudPlatform/kube-jenkins-imager](https://github.com/GoogleCloudPlatform/kube-jenkins-imager) for a complete tutorial that uses the `nginx-ssl-proxy` in Kubernetes.
-
 ## Generating test certificates
 
 Use the setup-certs.sh script to generate test certificates. It will create your own Certificate Authority and
@@ -73,3 +67,10 @@ To run an SSL termination proxy you must have an existing SSL certificate and ke
       -v /path/to/secrets/htpasswd:/etc/secrets/htpasswd \
       nginx-ssl-proxy
     ```
+
+ ## Connecting to a certification service
+
+ The nginx file supports proxying `/.well-known/acme-challenge` requests. The
+ destination should be defined using the CERT_SERVICE env variable.
+
+ The CERT_SERVICE will receive all requests to `/.well-known/acme-challenge`

--- a/nginx/letsencrypt.conf
+++ b/nginx/letsencrypt.conf
@@ -1,0 +1,3 @@
+location /.well-known/acme-challenge {
+   alias /tmp/letsencrypt/.well-known/acme-challenge;
+}

--- a/nginx/letsencrypt.conf
+++ b/nginx/letsencrypt.conf
@@ -1,3 +1,8 @@
 location /.well-known/acme-challenge {
-   alias /tmp/letsencrypt/.well-known/acme-challenge;
+    proxy_set_header        Host $host;
+    proxy_set_header        X-Real-IP $remote_addr;
+    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header        X-Forwarded-Proto $scheme;
+    proxy_pass              http://cert_service;
+    proxy_read_timeout      90;
 }

--- a/nginx/proxy_nossl.conf
+++ b/nginx/proxy_nossl.conf
@@ -5,7 +5,7 @@ upstream target_service {
 server {
   server_name _;
   listen 80;
-  
+
   location / {
     proxy_set_header        Host $host;
     proxy_set_header        X-Real-IP $remote_addr;
@@ -14,6 +14,6 @@ server {
     proxy_pass http://target_service;
     proxy_read_timeout  90;
     #auth_basic              "Restricted";
-    #auth_basic_user_file    /etc/secrets/htpasswd; 
+    #auth_basic_user_file    /etc/secrets/htpasswd;
   }
 }

--- a/nginx/proxy_ssl.conf
+++ b/nginx/proxy_ssl.conf
@@ -2,9 +2,9 @@ upstream target_service {
   server {{TARGET_SERVICE}};
 }
 
-upstream cert_service {
-  server {{CERT_SERVICE}};
-}
+#letsencrypt# upstream cert_service {
+#letsencrypt#   server {{CERT_SERVICE}};
+#letsencrypt# }
 
 
 server {
@@ -15,7 +15,7 @@ server {
     return 301 https://$host$request_uri;
   }
 
-  include /etc/nginx/snippets/letsencrypt.conf;
+  #letsencrypt# include /etc/nginx/snippets/letsencrypt.conf;
 
 }
 

--- a/nginx/proxy_ssl.conf
+++ b/nginx/proxy_ssl.conf
@@ -2,6 +2,11 @@ upstream target_service {
   server {{TARGET_SERVICE}};
 }
 
+upstream cert_service {
+  server {{CERT_SERVICE}};
+}
+
+
 server {
   server_name _;
   listen 80;

--- a/nginx/proxy_ssl.conf
+++ b/nginx/proxy_ssl.conf
@@ -5,11 +5,17 @@ upstream target_service {
 server {
   server_name _;
   listen 80;
-  return 301 https://$host$request_uri;
+
+  location / {
+    return 301 https://$host$request_uri;
+  }
+
+  include /etc/nginx/snippets/letsencrypt.conf;
+
 }
 
 server {
-  server_name _; 
+  server_name _;
   listen 443;
 
   ssl on;
@@ -20,20 +26,20 @@ server {
   ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
   ssl_ciphers ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-RSA-RC4-SHA:AES128-GCM-SHA256:HIGH:!RC4:!MD5:!aNULL:!EDH:!CAMELLIA;
   ssl_prefer_server_ciphers on;
-  
+
   ssl_session_cache shared:SSL:10m;
   ssl_session_timeout 10m;
- 
+
   ssl_session_tickets off;
   ssl_stapling on;
   ssl_stapling_verify on;
   resolver 8.8.8.8 8.8.4.4 valid=300s;
   resolver_timeout 5s;
- 
+
   add_header Strict-Transport-Security max-age=15638400;
   add_header X-Frame-Options DENY;
   add_header X-Content-Type-Options nosniff;
- 
+
   location / {
       proxy_set_header        Host $host;
       proxy_set_header        X-Real-IP $remote_addr;
@@ -44,7 +50,6 @@ server {
       proxy_read_timeout      90;
       proxy_redirect          http:// https://;
       #auth_basic              "Restricted";
-      #auth_basic_user_file    /etc/secrets/htpasswd; 
+      #auth_basic_user_file    /etc/secrets/htpasswd;
   }
 }
-

--- a/setup-certs.sh
+++ b/setup-certs.sh
@@ -15,7 +15,7 @@ SERVER_CSR="${LOCATION}/server.csr"
 echo $SERVER_KEY, $SERVER_CERT, $DHPARAM, $CA_KEY
 
 printf "# Create new dhparam. This may take a few minutes...\n"
-# openssl dhparam -out $DHPARAM 2048
+openssl dhparam -out $DHPARAM 2048
 
 printf "\n# Create the CA...\n"
 # Create the CA Key and Certificate for signing Client Certs

--- a/start.sh
+++ b/start.sh
@@ -54,5 +54,4 @@ sed -i "s/{{TARGET_SERVICE}}/${TARGET_SERVICE}/g;" /etc/nginx/conf.d/proxy.conf
 sed -i "s/{{CERT_SERVICE}}/${CERT_SERVICE}/g;" /etc/nginx/conf.d/proxy.conf
 
 echo "Starting nginx..."
-cat /etc/nginx/conf.d/proxy.conf
 nginx -g 'daemon off;'

--- a/start.sh
+++ b/start.sh
@@ -48,10 +48,13 @@ if [ -n "${CERT_SERVICE_PORT_ENV_NAME+1}" ]; then
   CERT_SERVICE="$CERT_SERVICE:${!CERT_SERVICE_PORT_ENV_NAME}"
 fi
 
+if [ -n "${CERT_SERVICE+1}" ]; then
+    # Tell nginx the address and port of the certification service.
+    sed -i "s/{{CERT_SERVICE}}/${CERT_SERVICE}/g;" /etc/nginx/conf.d/proxy.conf
+    sed -i "s/#letsencrypt# //g;" /etc/nginx/conf.d/proxy.conf
+fi
 # Tell nginx the address and port of the service to proxy to
 sed -i "s/{{TARGET_SERVICE}}/${TARGET_SERVICE}/g;" /etc/nginx/conf.d/proxy.conf
-# Tell nginx the address and port of the certification service.
-sed -i "s/{{CERT_SERVICE}}/${CERT_SERVICE}/g;" /etc/nginx/conf.d/proxy.conf
 
 echo "Starting nginx..."
 nginx -g 'daemon off;'

--- a/start.sh
+++ b/start.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 
-# Env says we're using SSL 
+# Env says we're using SSL
 if [ -n "${ENABLE_SSL+1}" ] && [ "${ENABLE_SSL,,}" = "true" ]; then
   echo "Enabling SSL..."
   cp /usr/src/proxy_ssl.conf /etc/nginx/conf.d/proxy.conf
@@ -21,7 +21,7 @@ else
   cp /usr/src/proxy_nossl.conf /etc/nginx/conf.d/proxy.conf
 fi
 
-# If an htpasswd file is provided, download and configure nginx 
+# If an htpasswd file is provided, download and configure nginx
 if [ -n "${ENABLE_BASIC_AUTH+1}" ] && [ "${ENABLE_BASIC_AUTH,,}" = "true" ]; then
   echo "Enabling basic auth..."
    sed -i "s/#auth_basic/auth_basic/g;" /etc/nginx/conf.d/proxy.conf
@@ -37,8 +37,22 @@ if [ -n "${SERVICE_PORT_ENV_NAME+1}" ]; then
   TARGET_SERVICE="$TARGET_SERVICE:${!SERVICE_PORT_ENV_NAME}"
 fi
 
+# If the CERT_SERVICE_HOST_ENV_NAME and CERT_SERVICE_PORT_ENV_NAME vars
+# are provided, they point to the env vars set by Kubernetes that contain the
+# actual target address and port of the encryption service. Override the
+# default with them.
+if [ -n "${CERT_SERVICE_HOST_ENV_NAME+1}" ]; then
+  CERT_SERVICE=${!CERT_SERVICE_HOST_ENV_NAME}
+fi
+if [ -n "${CERT_SERVICE_PORT_ENV_NAME+1}" ]; then
+  CERT_SERVICE="$CERT_SERVICE:${!CERT_SERVICE_PORT_ENV_NAME}"
+fi
+
 # Tell nginx the address and port of the service to proxy to
 sed -i "s/{{TARGET_SERVICE}}/${TARGET_SERVICE}/g;" /etc/nginx/conf.d/proxy.conf
+# Tell nginx the address and port of the certification service.
+sed -i "s/{{CERT_SERVICE}}/${CERT_SERVICE}/g;" /etc/nginx/conf.d/proxy.conf
 
 echo "Starting nginx..."
+cat /etc/nginx/conf.d/proxy.conf
 nginx -g 'daemon off;'


### PR DESCRIPTION
Requests to `well-known/acme-challenge/<challenge>` will be routed through to another container.

This allows you to have another container take care of all certificate gathering - for example this one:

https://github.com/ployst/docker/pull/2
