### PR TITLE
Add server name support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,11 @@ WORKDIR /usr/src
 ADD start.sh /usr/src/
 ADD nginx/nginx.conf /etc/nginx/
 ADD nginx/proxy*.conf /usr/src/
+ADD nginx/default*.conf /usr/src/
 
 RUN mkdir /etc/nginx/snippets/
 RUN mkdir -p /tmp/letsencrypt/.well-known/acme-challenge/
 RUN echo "OK" > /tmp/letsencrypt/.well-known/acme-challenge/health
 ADD nginx/letsencrypt.conf /etc/nginx/snippets/letsencrypt.conf
 
-ENTRYPOINT ./start.sh
+CMD ["./start.sh"]

--- a/README.md
+++ b/README.md
@@ -74,3 +74,9 @@ To run an SSL termination proxy you must have an existing SSL certificate and ke
  destination should be defined using the CERT_SERVICE env variable.
 
  The CERT_SERVICE will receive all requests to `/.well-known/acme-challenge`
+
+ ## Other env vars:
+
+  - **SERVER_NAME**
+    If set, this must be provided and will be set as the value in the
+    `server_name` directive.

--- a/nginx/default_nossl.conf
+++ b/nginx/default_nossl.conf
@@ -1,0 +1,5 @@
+server {
+    listen       80 default_server;
+    server_name  _;
+    return       444;
+}

--- a/nginx/default_ssl.conf
+++ b/nginx/default_ssl.conf
@@ -1,12 +1,15 @@
+server {
+     listen 80 default;
+     return 444;
+}
 
 server {
-    listen       80;
-    listen       443 default_server ssl;
-    server_name  _;
+    listen 443 default;
 
     ssl_certificate /etc/secrets/proxycert;
     ssl_certificate_key /etc/secrets/proxykey;
     ssl_dhparam /etc/secrets/dhparam;
 
-    return       444;
+    ssl on;
+    return 444;
 }

--- a/nginx/default_ssl.conf
+++ b/nginx/default_ssl.conf
@@ -1,0 +1,12 @@
+
+server {
+    listen       80;
+    listen       443 default_server ssl;
+    server_name  _;
+
+    ssl_certificate /etc/secrets/proxycert;
+    ssl_certificate_key /etc/secrets/proxykey;
+    ssl_dhparam /etc/secrets/dhparam;
+
+    return       444;
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -27,5 +27,5 @@ http {
 
     #gzip  on;
     client_max_body_size 20M;
-    include /etc/nginx/conf.d/proxy.conf;
+    include /etc/nginx/conf.d/*;
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -27,5 +27,7 @@ http {
 
     #gzip  on;
     client_max_body_size 20M;
-    include /etc/nginx/conf.d/*;
+    include /etc/nginx/conf.d/proxy.conf;
+    include /etc/nginx/conf.d/default.conf;
+
 }

--- a/nginx/proxy_nossl.conf
+++ b/nginx/proxy_nossl.conf
@@ -3,7 +3,7 @@ upstream target_service {
 }
 
 server {
-  server_name _;
+  server_name {{SERVER_NAME}};
   listen 80;
 
   location / {
@@ -11,8 +11,8 @@ server {
     proxy_set_header        X-Real-IP $remote_addr;
     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header        X-Forwarded-Proto $scheme;
-    proxy_pass http://target_service;
-    proxy_read_timeout  90;
+    proxy_pass              http://target_service;
+    proxy_read_timeout      90;
     #auth_basic              "Restricted";
     #auth_basic_user_file    /etc/secrets/htpasswd;
   }

--- a/nginx/proxy_ssl.conf
+++ b/nginx/proxy_ssl.conf
@@ -8,7 +8,7 @@ upstream target_service {
 
 
 server {
-  server_name _;
+  server_name {{SERVER_NAME}};
   listen 80;
 
   location / {
@@ -20,7 +20,7 @@ server {
 }
 
 server {
-  server_name _;
+  server_name {{SERVER_NAME}};
   listen 443;
 
   ssl on;

--- a/nginx/proxy_ssl.conf
+++ b/nginx/proxy_ssl.conf
@@ -35,7 +35,6 @@ server {
   ssl_session_cache shared:SSL:10m;
   ssl_session_timeout 10m;
 
-  ssl_session_tickets off;
   ssl_stapling on;
   ssl_stapling_verify on;
   resolver 8.8.8.8 8.8.4.4 valid=300s;

--- a/setup-certs.sh
+++ b/setup-certs.sh
@@ -15,7 +15,7 @@ SERVER_CSR="${LOCATION}/server.csr"
 echo $SERVER_KEY, $SERVER_CERT, $DHPARAM, $CA_KEY
 
 printf "# Create new dhparam. This may take a few minutes...\n"
-openssl dhparam -out $DHPARAM 2048
+openssl dhparam -out $DHPARAM 128
 
 printf "\n# Create the CA...\n"
 # Create the CA Key and Certificate for signing Client Certs

--- a/start.sh
+++ b/start.sh
@@ -16,9 +16,11 @@
 if [ -n "${ENABLE_SSL+1}" ] && [ "${ENABLE_SSL,,}" = "true" ]; then
   echo "Enabling SSL..."
   cp /usr/src/proxy_ssl.conf /etc/nginx/conf.d/proxy.conf
+  cp /usr/src/default_ssl.conf /etc/nginx/conf.d/default.conf
 else
   # No SSL
   cp /usr/src/proxy_nossl.conf /etc/nginx/conf.d/proxy.conf
+  cp /usr/src/default_nossl.conf /etc/nginx/conf.d/default.conf
 fi
 
 # If an htpasswd file is provided, download and configure nginx
@@ -54,7 +56,11 @@ if [ -n "${CERT_SERVICE+1}" ]; then
     sed -i "s/#letsencrypt# //g;" /etc/nginx/conf.d/proxy.conf
 fi
 # Tell nginx the address and port of the service to proxy to
-sed -i "s/{{TARGET_SERVICE}}/${TARGET_SERVICE}/g;" /etc/nginx/conf.d/proxy.conf
+sed -i "s|{{TARGET_SERVICE}}|${TARGET_SERVICE}|" /etc/nginx/conf.d/proxy.conf
+
+# Tell nginx the name of the service
+sed -i "s/{{SERVER_NAME}}/${SERVER_NAME}/g;" /etc/nginx/conf.d/proxy.conf
+
 
 echo "Starting nginx..."
 nginx -g 'daemon off;'


### PR DESCRIPTION
This will prevent the TARGET_SERVICE from serving requests that were never intended for it.
