### PR TITLE
Proxy using http 1.1 & add auto depoy

### DIFF
--- a/nginx/proxy_nossl.conf
+++ b/nginx/proxy_nossl.conf
@@ -13,6 +13,7 @@ server {
     proxy_set_header        X-Forwarded-Proto $scheme;
     proxy_pass              http://target_service;
     proxy_read_timeout      90;
+    proxy_http_version      1.1;
     #auth_basic              "Restricted";
     #auth_basic_user_file    /etc/secrets/htpasswd;
   }

--- a/nginx/proxy_ssl.conf
+++ b/nginx/proxy_ssl.conf
@@ -53,6 +53,7 @@ server {
       proxy_pass              http://target_service;
       proxy_read_timeout      90;
       proxy_redirect          http:// https://;
+      proxy_http_version      1.1;
       #auth_basic              "Restricted";
       #auth_basic_user_file    /etc/secrets/htpasswd;
   }


### PR DESCRIPTION
This enables affords gzip compression the backend services that are using the default nginx `gzip_http_version` of 1.1

Inspired by [this article](http://reinout.vanrees.org/weblog/2015/11/19/nginx-proxy-gzip.html)
